### PR TITLE
Update play.py

### DIFF
--- a/reconchess/play.py
+++ b/reconchess/play.py
@@ -29,8 +29,8 @@ def play_local_game(white_player: Player, black_player: Player, game: LocalGame 
     black_name = black_player.__class__.__name__
     game.store_players(white_name, black_name)
 
-    white_player.handle_game_start(chess.WHITE, game.board.copy(), white_name)
-    black_player.handle_game_start(chess.BLACK, game.board.copy(), black_name)
+    white_player.handle_game_start(chess.WHITE, game.board.copy(), black_name)
+    black_player.handle_game_start(chess.BLACK, game.board.copy(), white_name)
     game.start()
 
     while not game.is_over():


### PR DESCRIPTION
The latest reconchess version passes opponent_name to bots in handle_game_start, but play_local_game accidentally passes a bot's own name to it (white received white_name and black received black_name). Flipping white_name and black_name is all that is needed to fix this. The play_remote_game counterpart does not have this problem.