### PR TITLE
Add multiprocessing version of local game

### DIFF
--- a/reconchess/__init__.py
+++ b/reconchess/__init__.py
@@ -2,6 +2,7 @@ from .game import Game, LocalGame, RemoteGame
 from .player import Player, load_player
 from .types import *
 from .utilities import is_illegal_castle, is_psuedo_legal_castle, ChessJSONEncoder, ChessJSONDecoder
-from .play import play_local_game, play_remote_game, play_turn, notify_opponent_move_results, play_sense, play_move
+from .play import play_local_game, play_remote_game, play_turn, notify_opponent_move_results, play_sense, play_move, \
+    play_multiprocessing_local_game
 from .history import Turn, GameHistory, GameHistoryEncoder, GameHistoryDecoder
 import chess

--- a/reconchess/game.py
+++ b/reconchess/game.py
@@ -445,7 +445,7 @@ class MultiprocessingLocalGame(RemoteGame):
         while True:
             self.queues['to moderator'].put((request,))
             response = self.queues['to player'].get()
-            if response is not None:
+            if response != 'Request unavailable':
                 return response
             else:
                 time.sleep(0.5)
@@ -454,7 +454,7 @@ class MultiprocessingLocalGame(RemoteGame):
         while True:
             self.queues['to moderator'].put((request, obj))
             response = self.queues['to player'].get()
-            if response is not None:
+            if response != 'Request unavailable':
                 return response
             else:
                 time.sleep(0.5)

--- a/reconchess/play.py
+++ b/reconchess/play.py
@@ -258,13 +258,13 @@ def _respond_to_requests(game: LocalGame, queues):
                 if on_own_turn:
                     queues[color]['to player'].put({'sense_actions': game.sense_actions()})
                 else:
-                    queues[color]['to player'].put(None)
+                    queues[color]['to player'].put('Request unavailable')
 
             elif request_command == 'move_actions':
                 if on_own_turn:
                     queues[color]['to player'].put({'move_actions': game.move_actions()})
                 else:
-                    queues[color]['to player'].put(None)
+                    queues[color]['to player'].put('Request unavailable')
 
             elif request_command == 'seconds_left':
                 if on_own_turn:
@@ -282,28 +282,28 @@ def _respond_to_requests(game: LocalGame, queues):
                 if on_own_turn:
                     queues[color]['to player'].put({'opponent_move_results': game.opponent_move_results()})
                 else:
-                    queues[color]['to player'].put(None)
+                    queues[color]['to player'].put('Request unavailable')
 
             elif request_command == 'sense':
                 request_value = request[1]
                 if on_own_turn:
                     queues[color]['to player'].put({'sense_result': game.sense(request_value['square'])})
                 else:
-                    queues[color]['to player'].put(None)
+                    queues[color]['to player'].put('Request unavailable')
 
             elif request_command == 'move':
                 request_value = request[1]
                 if on_own_turn:
                     queues[color]['to player'].put({'move_result': game.move(request_value['requested_move'])})
                 else:
-                    queues[color]['to player'].put(None)
+                    queues[color]['to player'].put('Request unavailable')
 
             elif request_command == 'end_turn':
                 if on_own_turn:
                     game.end_turn()
                     queues[color]['to player'].put({'end_turn': 'done'})
                 else:
-                    queues[color]['to player'].put(None)
+                    queues[color]['to player'].put('Request unavailable')
 
             elif request_command == 'game_status':
                 queues[color]['to player'].put({'is_over': game.is_over(), 'is_my_turn': on_own_turn})

--- a/reconchess/play.py
+++ b/reconchess/play.py
@@ -276,7 +276,7 @@ def _respond_to_requests(game: LocalGame, queues):
                 queues[color]['to player'].put({'ready': 'ready'})
 
             elif request_command == 'is_my_turn':
-                queues[color]['to player'].put({'is_my_turn': on_own_turn or game.is_over()})
+                queues[color]['to player'].put({'is_my_turn': on_own_turn and not game.is_over()})
 
             elif request_command == 'opponent_move_results':
                 if on_own_turn:

--- a/reconchess/play.py
+++ b/reconchess/play.py
@@ -1,8 +1,10 @@
 import chess
 from .types import *
 from .player import Player
-from .game import Game, LocalGame, RemoteGame
+from .game import Game, LocalGame, RemoteGame, MultiprocessingLocalGame
 from .history import GameHistory
+
+import multiprocessing as mp
 
 
 def play_local_game(white_player: Player, black_player: Player, game: LocalGame = None,
@@ -149,3 +151,175 @@ def play_move(game: Game, player: Player, move_actions: List[chess.Move], end_tu
 
     if end_turn_last:
         game.end_turn()
+
+
+def play_multiprocessing_local_game(white_player_class, black_player_class,
+                                    game: LocalGame = None, seconds_per_player: float = 900) \
+        -> Tuple[Optional[Color], Optional[WinReason], GameHistory]:
+    """
+    Plays a game between the two players passed in. Uses :class:`LocalGame` to run the game, but enables behavior
+    similar to :class:`RemoteGame` by multiprocessing. Unlike :func:`play_local_game` and :func:`play_remote_game`, the
+    players here must be passed as un-initialized classes; TroutBot rather than TroutBot().
+
+    :param white_player_class: The white :class:`Player` un-initialized.
+    :param black_player_class: The black :class:`Player` un-initialized.
+    :param game: The :class:`LocalGame` object to use.
+    :param seconds_per_player: The time each player has to play. Only used if `game` is not passed in.
+    :return: The results of the game, also passed to each player via :meth:`Player.handle_game_end`.
+    """
+
+    if game is None:
+        game = LocalGame(seconds_per_player=seconds_per_player)
+
+    white_name = white_player_class.__name__
+    black_name = black_player_class.__name__
+    game.store_players(white_name, black_name)
+
+    # Stored player names become inaccessible from game (except by cheating: game._LocalGame__game_history...), instead:
+    game.player_names = {
+        chess.WHITE: white_name,
+        chess.BLACK: black_name
+    }
+
+    player_queues = {
+        chess.WHITE: {'to player': mp.Queue(), 'to moderator': mp.Queue()},
+        chess.BLACK: {'to player': mp.Queue(), 'to moderator': mp.Queue()}
+    }
+
+    player_processes = [
+        mp.Process(target=_play_in_multiprocessing_local_game, args=(player_queues[chess.BLACK], black_player_class)),
+        mp.Process(target=_play_in_multiprocessing_local_game, args=(player_queues[chess.WHITE], white_player_class))
+    ]
+
+    [process.start() for process in player_processes]
+
+    game.start()
+
+    while any([process.is_alive() for process in player_processes]):
+        _respond_to_requests(game, player_queues)
+
+    winner_color = game.get_winner_color()
+    win_reason = game.get_win_reason()
+    game_history = game.get_game_history()
+
+    return winner_color, win_reason, game_history
+
+
+def _play_in_multiprocessing_local_game(queues, player_class):
+    """
+    Each player in a :class:`MultiprocessingLocalGame` uses this to participate in parallel. It mimics
+    :func:`play_remote_game`, but replaces server requests with multiprocessing queues.
+
+    :param queues: This player's dictionary of multiprocessing queues keyed 'to player' and 'to moderator'
+    :param player_class: The :class:`Player` un-initialized.
+    """
+    game = MultiprocessingLocalGame(queues)
+    player = player_class()
+
+    player.handle_game_start(game.get_player_color(), game.get_starting_board(), game.get_opponent_name())
+    game.start()
+
+    while not game.is_over():
+        play_turn(game, player, end_turn_last=False)
+
+    winner_color = game.get_winner_color()
+    win_reason = game.get_win_reason()
+    game_history = game.get_game_history()
+
+    player.handle_game_end(winner_color, win_reason, game_history)
+
+
+def _respond_to_requests(game: LocalGame, queues):
+    """
+    Pass information between the moderator which runs a :class:`LocalGame` and each player which run their own
+    :class:`RemoteGame` sub-class, :class:`MultiprocessingLocalGame`.
+
+    :param game: The :class:`LocalGame` object to reference for neutral game-state information.
+    :param queues: Multiprocessing Queues for communicating with the players. Stored as a nested dictionary of player
+    color and queue direction: queues[chess.WHITE | chess.BLACK]['to player' | 'to moderator'].
+    """
+    for color in [game.turn, not game.turn]:
+        if not queues[color]['to moderator'].empty():
+            request = queues[color]['to moderator'].get()
+            request_command = request[0]
+            on_own_turn = game.turn == color
+
+            if request_command == 'color':
+                queues[color]['to player'].put({'color': color})
+
+            elif request_command == 'starting_board':
+                queues[color]['to player'].put({'board': chess.Board()})
+
+            elif request_command == 'opponent_name':
+                queues[color]['to player'].put({'opponent_name': game.player_names[not color]})
+                # This attribute was added in moderate_multiprocessing_local_game, since the names become hard to access
+
+            elif request_command == 'sense_actions':
+                if on_own_turn:
+                    queues[color]['to player'].put({'sense_actions': game.sense_actions()})
+                else:
+                    queues[color]['to player'].put(None)
+
+            elif request_command == 'move_actions':
+                if on_own_turn:
+                    queues[color]['to player'].put({'move_actions': game.move_actions()})
+                else:
+                    queues[color]['to player'].put(None)
+
+            elif request_command == 'seconds_left':
+                if on_own_turn:
+                    queues[color]['to player'].put({'seconds_left': game.get_seconds_left()})
+                else:
+                    queues[color]['to player'].put({'seconds_left': game.seconds_left_by_color[color]})
+
+            elif request_command == 'ready':
+                queues[color]['to player'].put({'ready': 'ready'})
+
+            elif request_command == 'is_my_turn':
+                queues[color]['to player'].put({'is_my_turn': on_own_turn or game.is_over()})
+
+            elif request_command == 'opponent_move_results':
+                if on_own_turn:
+                    queues[color]['to player'].put({'opponent_move_results': game.opponent_move_results()})
+                else:
+                    queues[color]['to player'].put(None)
+
+            elif request_command == 'sense':
+                request_value = request[1]
+                if on_own_turn:
+                    queues[color]['to player'].put({'sense_result': game.sense(request_value['square'])})
+                else:
+                    queues[color]['to player'].put(None)
+
+            elif request_command == 'move':
+                request_value = request[1]
+                if on_own_turn:
+                    queues[color]['to player'].put({'move_result': game.move(request_value['requested_move'])})
+                else:
+                    queues[color]['to player'].put(None)
+
+            elif request_command == 'end_turn':
+                if on_own_turn:
+                    game.end_turn()
+                    queues[color]['to player'].put({'end_turn': 'done'})
+                else:
+                    queues[color]['to player'].put(None)
+
+            elif request_command == 'game_status':
+                queues[color]['to player'].put({'is_over': game.is_over(), 'is_my_turn': on_own_turn})
+
+            elif request_command == 'winner_color':
+                queues[color]['to player'].put({'winner_color': game.get_winner_color()})
+
+            elif request_command == 'win_reason':
+                queues[color]['to player'].put({'win_reason': game.get_win_reason()})
+
+            elif request_command == 'game_history':
+                queues[color]['to player'].put({'game_history': game.get_game_history()})
+
+            else:
+                raise KeyError(f'Requested command {request_command} is not implemented')
+
+            # After each action, check if the game has ended
+            if game.is_over():
+                game.end()

--- a/reconchess/scripts/rc_mp_bot_match.py
+++ b/reconchess/scripts/rc_mp_bot_match.py
@@ -1,0 +1,43 @@
+import argparse
+import datetime
+import traceback
+import chess
+from reconchess import load_player, LocalGame, play_multiprocessing_local_game
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('white_bot_path', help='path to white bot source file')
+    parser.add_argument('black_bot_path', help='path to black bot source file')
+    parser.add_argument('--seconds_per_player', default=900, type=float,
+                        help='number of seconds each player has to play the entire game.')
+    args = parser.parse_args()
+
+    white_bot_name, white_player_cls = load_player(args.white_bot_path)
+    black_bot_name, black_player_cls = load_player(args.black_bot_path)
+
+    game = LocalGame(args.seconds_per_player)
+
+    try:
+        winner_color, win_reason, history = play_multiprocessing_local_game(white_player_cls, black_player_cls, game=game)
+
+        winner = 'Draw' if winner_color is None else chess.COLOR_NAMES[winner_color]
+    except:
+        traceback.print_exc()
+        game.end()
+
+        winner = 'ERROR'
+        history = game.get_game_history()
+
+    print('Game Over!')
+    print('Winner: {}!'.format(winner))
+
+    timestamp = datetime.datetime.now().strftime('%Y_%m_%d-%H_%M_%S')
+
+    replay_path = '{}-{}-{}-{}.json'.format(white_bot_name, black_bot_name, winner, timestamp)
+    print('Saving replay to {}...'.format(replay_path))
+    history.save(replay_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'rc-bot-match=reconchess.scripts.rc_bot_match:main',
+            'rc-mp-bot-match=reconchess.scripts.rc_mp_bot_match:main',
             'rc-play=reconchess.scripts.rc_play:main',
             'rc-replay=reconchess.scripts.rc_replay:main',
             'rc-playback=reconchess.scripts.rc_playback:main',


### PR DESCRIPTION
This is a migration of a particularly useful tool used in the development of the StrangeFish bot into the reconchess package. The new code very closely parallels existing classes, scripts, and functions, but it is still a large addition to the package; if the reconchess authors/maintainers would therefore prefer this pull request _not_ be added to reconchess, that would of course be understandable.

`MultiprocessingLocalGame` is a sub-class of `RemoteGame` which enables bots to play in a `LocalGame` that more closely mimics the behaviors of a server-based `RemoteGame`. In `play_multiprocessing_local_game`, unlike in the existing `play_local_game`, the two participating bots can continue to work during each other's turn. Recognizing and leveraging this difference between `LocalGame` and `RemoteGame` is an important step in the development of reconchess bots.

This pull request adds five items to the package:

1. `play_multiprocessing_local_game`, a copy of `play_local_game` adapted to use multiprocessing and queues to allow both players to work simultaneously. This process is the game 'moderator' which maintains a `LocalGame`.

2. `_play_in_multiprocessing_local_game`, a copy of `play_remote_game` adapted to use queues so that each player sees the game as though in a `RemoteGame`.

3. `MultiprocessingLocalGame`, a sub-class of `RemoteGame` that replaces server requests with multiprocessing queues in order to keep the game local.

4. `_respond_to_requests`, a server-emulating function that manages communications between the moderator of the `LocalGame` and the players each in their own `MultiprocessingLocalGame`. For this one item, the reconchess package had no similar code to reference; `_respond_to_requests` is therefore particularly open to revisions.

5. `scripts/rc_mp_bot_match.py`, a near copy of `scripts/rc_bot_match.py` which replaces `play_local_game` with `play_multiprocessing_local_game`.

This version of the tool was written to match the existing package code as closely as possible. One remaining area of debate is the import of `multiprocessing` in `play.py`. Importing this package in the existing module was deemed less intrusive than creating a separate `mp_play.py` for the multiprocessing functions, but if the reconchess authors disagree, that could easily be changed.