### PR TITLE
Faster move generation and execution

### DIFF
--- a/reconchess/game.py
+++ b/reconchess/game.py
@@ -188,8 +188,7 @@ class LocalGame(Game):
         """
         :return: List of moves that are possible with only knowledge of your pieces
         """
-        return None if self._is_finished else moves_without_opponent_pieces(self.board) + pawn_capture_moves_on(
-            self.board)
+        return None if self._is_finished else move_actions(self.board)
 
     def opponent_move_results(self) -> Optional[Square]:
         return self.move_results
@@ -256,21 +255,7 @@ class LocalGame(Game):
         return requested_move, taken_move, opt_capture_square
 
     def _revise_move(self, move):
-        # if its a legal move, don't change it at all. note that board.generate_psuedo_legal_moves() does not
-        # include psuedo legal castles
-        if self.board.is_pseudo_legal(move) or is_psuedo_legal_castle(self.board, move):
-            return move
-
-        # note: if there are pieces in the way, we DONT capture them
-        if is_illegal_castle(self.board, move):
-            return None
-
-        # if the piece is a sliding piece, slide it as far as it can go
-        piece = self.board.piece_at(move.from_square)
-        if piece.piece_type in [chess.PAWN, chess.ROOK, chess.BISHOP, chess.QUEEN]:
-            move = slide_move(self.board, move)
-
-        return move if self.board.is_pseudo_legal(move) else None
+        return revise_move(self.board, move)
 
     def end_turn(self):
         """

--- a/reconchess/game.py
+++ b/reconchess/game.py
@@ -258,7 +258,7 @@ class LocalGame(Game):
     def _revise_move(self, move):
         # if its a legal move, don't change it at all. note that board.generate_psuedo_legal_moves() does not
         # include psuedo legal castles
-        if move in self.board.generate_pseudo_legal_moves() or is_psuedo_legal_castle(self.board, move):
+        if self.board.is_pseudo_legal(move) or is_psuedo_legal_castle(self.board, move):
             return move
 
         # note: if there are pieces in the way, we DONT capture them
@@ -270,7 +270,7 @@ class LocalGame(Game):
         if piece.piece_type in [chess.PAWN, chess.ROOK, chess.BISHOP, chess.QUEEN]:
             move = slide_move(self.board, move)
 
-        return move if move in self.board.generate_pseudo_legal_moves() else None
+        return move if self.board.is_pseudo_legal(move) else None
 
     def end_turn(self):
         """

--- a/reconchess/utilities.py
+++ b/reconchess/utilities.py
@@ -72,7 +72,8 @@ def capture_square_of_move(board: chess.Board, move: Optional[chess.Move]) -> Op
 
 def without_opponent_pieces(board: chess.Board) -> chess.Board:
     """Returns a copy of `board` with the opponent's pieces removed."""
-    return board.transform(lambda bb: bb & board.occupied_co[board.turn])
+    mine = board.occupied_co[board.turn]
+    return board.transform(lambda bb: bb & mine)
 
 
 def moves_without_opponent_pieces(board: chess.Board, has_opponent_pieces=True) -> List[chess.Move]:

--- a/reconchess/utilities.py
+++ b/reconchess/utilities.py
@@ -102,6 +102,31 @@ def pawn_capture_moves_on(board: chess.Board) -> List[chess.Move]:
     return pawn_capture_moves
 
 
+def revise_move(board, move):
+    # if its a legal move, don't change it at all. note that board.generate_psuedo_legal_moves() does not
+    # include psuedo legal castles
+    if board.is_pseudo_legal(move) or is_psuedo_legal_castle(board, move):
+        return move
+
+    # note: if there are pieces in the way, we DONT capture them
+    if is_illegal_castle(board, move):
+        return None
+
+    # if the piece is a sliding piece, slide it as far as it can go
+    piece = board.piece_at(move.from_square)
+    if piece.piece_type in [chess.PAWN, chess.ROOK, chess.BISHOP, chess.QUEEN]:
+        move = slide_move(board, move)
+
+    return move if board.is_pseudo_legal(move) else None
+
+
+def move_actions(board: chess.Board) -> List[chess.Move]:
+    """
+    :return: List of moves that are possible with only knowledge of your pieces
+    """
+    return moves_without_opponent_pieces(board) + pawn_capture_moves_on(board)
+
+
 class ChessJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, chess.Piece):

--- a/reconchess/utilities.py
+++ b/reconchess/utilities.py
@@ -44,12 +44,16 @@ def is_illegal_castle(board: chess.Board, move: chess.Move) -> bool:
 
 
 def slide_move(board: chess.Board, move: chess.Move) -> Optional[chess.Move]:
-    psuedo_legal_moves = list(board.generate_pseudo_legal_moves())
-    squares = list(chess.SquareSet(chess.between(move.from_square, move.to_square))) + [move.to_square]
-    squares = sorted(squares, key=lambda s: chess.square_distance(s, move.from_square), reverse=True)
-    for slide_square in squares:
+    # We iterate longest to shortest so the revised move is the longest pseudo-legal move.
+    # If the to-square < from-square then we want our list in sorted order.
+    # Otherwise we want it in reverse order.
+    # In either case, we need to add the to-square to the front of our list manually.
+    squares = chess.SquareSet(chess.between(move.from_square, move.to_square))
+    if move.to_square > move.from_square:
+        squares = reversed(squares)
+    for slide_square in [move.to_square] + list(squares):
         revised = chess.Move(move.from_square, slide_square, move.promotion)
-        if revised in psuedo_legal_moves:
+        if board.is_pseudo_legal(revised):
             return revised
     return None
 
@@ -68,12 +72,7 @@ def capture_square_of_move(board: chess.Board, move: Optional[chess.Move]) -> Op
 
 def without_opponent_pieces(board: chess.Board) -> chess.Board:
     """Returns a copy of `board` with the opponent's pieces removed."""
-    b = board.copy()
-    b.ep_square = None
-    for piece_type in chess.PIECE_TYPES:
-        for sq in b.pieces(piece_type, not board.turn):
-            b.remove_piece_at(sq)
-    return b
+    return board.transform(lambda bb: bb & board.occupied_co[board.turn])
 
 
 def moves_without_opponent_pieces(board: chess.Board) -> List[chess.Move]:
@@ -96,7 +95,7 @@ def pawn_capture_moves_on(board: chess.Board) -> List[chess.Move]:
             pawn_capture_moves.append(chess.Move(pawn_square, attacked_square))
 
             # add in promotion moves
-            if attacked_square in chess.SquareSet(chess.BB_BACKRANKS):
+            if attacked_square in BACK_RANKS:
                 for piece_type in chess.PIECE_TYPES[1:-1]:
                     pawn_capture_moves.append(chess.Move(pawn_square, attacked_square, promotion=piece_type))
 

--- a/reconchess/utilities.py
+++ b/reconchess/utilities.py
@@ -76,22 +76,20 @@ def without_opponent_pieces(board: chess.Board) -> chess.Board:
     return board.transform(lambda bb: bb & mine)
 
 
-def moves_without_opponent_pieces(board: chess.Board, has_opponent_pieces=True) -> List[chess.Move]:
+def moves_without_opponent_pieces(board: chess.Board) -> List[chess.Move]:
     """Generates moves on `board` with the opponent's pieces removed."""
-    no_opponents_board = without_opponent_pieces(board) if has_opponent_pieces else board
-    return list(no_opponents_board.generate_pseudo_legal_moves())
+    return list(without_opponent_pieces(board).generate_pseudo_legal_moves())
 
 
-def pawn_capture_moves_on(board: chess.Board, has_opponent_pieces=True) -> List[chess.Move]:
+def pawn_capture_moves_on(board: chess.Board) -> List[chess.Move]:
     """Generates all pawn captures on `board`, even if there is no piece to capture. All promotion moves are included."""
     pawn_capture_moves = []
-
-    no_opponents_board = without_opponent_pieces(board) if has_opponent_pieces else board
 
     for pawn_square in board.pieces(chess.PAWN, board.turn):
         for attacked_square in board.attacks(pawn_square):
             # skip this square if one of our own pieces are on the square
-            if no_opponents_board.piece_at(attacked_square):
+            attacked_piece = board.piece_at(attacked_square)
+            if attacked_piece and attacked_piece.color == board.turn:
                 continue
 
             pawn_capture_moves.append(chess.Move(pawn_square, attacked_square))
@@ -126,8 +124,7 @@ def move_actions(board: chess.Board) -> List[chess.Move]:
     """
     :return: List of moves that are possible with only knowledge of your pieces
     """
-    board = without_opponent_pieces(board)
-    return moves_without_opponent_pieces(board, False) + pawn_capture_moves_on(board, False)
+    return moves_without_opponent_pieces(board) + pawn_capture_moves_on(board)
 
 
 class ChessJSONEncoder(json.JSONEncoder):

--- a/reconchess/utilities.py
+++ b/reconchess/utilities.py
@@ -75,16 +75,17 @@ def without_opponent_pieces(board: chess.Board) -> chess.Board:
     return board.transform(lambda bb: bb & board.occupied_co[board.turn])
 
 
-def moves_without_opponent_pieces(board: chess.Board) -> List[chess.Move]:
+def moves_without_opponent_pieces(board: chess.Board, has_opponent_pieces=True) -> List[chess.Move]:
     """Generates moves on `board` with the opponent's pieces removed."""
-    return list(without_opponent_pieces(board).generate_pseudo_legal_moves())
+    no_opponents_board = without_opponent_pieces(board) if has_opponent_pieces else board
+    return list(no_opponents_board.generate_pseudo_legal_moves())
 
 
-def pawn_capture_moves_on(board: chess.Board) -> List[chess.Move]:
+def pawn_capture_moves_on(board: chess.Board, has_opponent_pieces=True) -> List[chess.Move]:
     """Generates all pawn captures on `board`, even if there is no piece to capture. All promotion moves are included."""
     pawn_capture_moves = []
 
-    no_opponents_board = without_opponent_pieces(board)
+    no_opponents_board = without_opponent_pieces(board) if has_opponent_pieces else board
 
     for pawn_square in board.pieces(chess.PAWN, board.turn):
         for attacked_square in board.attacks(pawn_square):
@@ -124,7 +125,8 @@ def move_actions(board: chess.Board) -> List[chess.Move]:
     """
     :return: List of moves that are possible with only knowledge of your pieces
     """
-    return moves_without_opponent_pieces(board) + pawn_capture_moves_on(board)
+    board = without_opponent_pieces(board)
+    return moves_without_opponent_pieces(board, False) + pawn_capture_moves_on(board, False)
 
 
 class ChessJSONEncoder(json.JSONEncoder):


### PR DESCRIPTION
This PR:

1. Relocates the `move_actions` and `revise_move` logic from `LocalGame` to `reconchess.utilities` for easier use by bot developers and
2. Optimizes those two functions and `slide_move`, which gives a ~5x speedup in random moving (example script below).

To test the performance, I ran the following

```
from reconchess.utilities import *
from chess import *

import random

def run(n=1_000):
    board = Board()
    for _ in range(n):
        move = random.choice(move_actions(board))
        revised = revise_move(board, move) or Move.null()
        board.push(revised)
        if board.king(WHITE) is None or board.king(BLACK) is None:
            board = Board()
    return board
```

On master you have to define the following (copied from LocalGame with no changes)

```
def move_actions(board):
    return moves_without_opponent_pieces(board) + pawn_capture_moves_on(board)

def revise_move(board, move):
    # if its a legal move, don't change it at all. note that board.generate_psuedo_legal_moves() does not
    # include psuedo legal castles
    if move in board.generate_pseudo_legal_moves() or is_psuedo_legal_castle(board, move):
        return move

    # note: if there are pieces in the way, we DONT capture them
    if is_illegal_castle(board, move):
        return None

    # if the piece is a sliding piece, slide it as far as it can go
    piece = board.piece_at(move.from_square)
    if piece.piece_type in [chess.PAWN, chess.ROOK, chess.BISHOP, chess.QUEEN]:
        move = slide_move(board, move)

    return move if move in board.generate_pseudo_legal_moves() else None
```

Before changes

```
%time random.seed(12890); run(100_000)
CPU times: user 53.9 s, sys: 190 ms, total: 54 s
Wall time: 55.8 s
```

After changes
```
%time random.seed(12890); run(100_000)
CPU times: user 10.6 s, sys: 79.7 ms, total: 10.7 s
Wall time: 11 s
```